### PR TITLE
Big general cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -80,7 +80,7 @@ jar {
     }
 }
 
-tasks.withType(JavaCompile) {
+tasks.withType(JavaCompile).configureEach {
     options.encoding = 'UTF-8'
     options.compilerArgs << '-Xlint:unchecked'
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,13 +6,13 @@ pluginManagement {
 }
 
 plugins {
-    id 'org.gradle.toolchains.foojay-resolver-convention' version '0.7.0'
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '0.8.0'
 }
 
 dependencyResolutionManagement {
     versionCatalogs {
         libs {
-            version('asm', '9.6')
+            version('asm', '9.7.1')
             library('asm',         'org.ow2.asm', 'asm'        ).versionRef('asm')
             library('asm-tree',    'org.ow2.asm', 'asm-tree'   ).versionRef('asm')
             library('asm-commons', 'org.ow2.asm', 'asm-commons').versionRef('asm')

--- a/src/main/java/cpw/mods/modlauncher/ArgumentHandler.java
+++ b/src/main/java/cpw/mods/modlauncher/ArgumentHandler.java
@@ -95,7 +95,7 @@ public class ArgumentHandler {
         addOptionToString(assetsDirOption, optionSet, args);
         addOptionToString(uuidOption, optionSet, args);
         List<?> nonOptionList = this.optionSet.nonOptionArguments();
-        nonOptionList.stream().map(Object::toString).forEach(args::add);
+        args.addAll(nonOptionList.stream().map(Object::toString).toList());
         return args.toArray(new String[0]);
     }
 

--- a/src/main/java/cpw/mods/modlauncher/ArgumentHandler.java
+++ b/src/main/java/cpw/mods/modlauncher/ArgumentHandler.java
@@ -99,7 +99,7 @@ public class ArgumentHandler {
         return args.toArray(new String[0]);
     }
 
-    private void addOptionToString(OptionSpec<?> option, OptionSet optionSet, List<String> appendTo) {
+    private static void addOptionToString(OptionSpec<?> option, OptionSet optionSet, List<String> appendTo) {
         if (optionSet.has(option)) {
             appendTo.add("--"+option.options().get(0));
             appendTo.add(option.value(optionSet).toString());

--- a/src/main/java/cpw/mods/modlauncher/ArgumentHandler.java
+++ b/src/main/java/cpw/mods/modlauncher/ArgumentHandler.java
@@ -55,7 +55,7 @@ public class ArgumentHandler {
         env.computePropertyIfAbsent(IEnvironment.Keys.ASSETSDIR.get(), f -> this.optionSet.valueOf(assetsDirOption));
         env.computePropertyIfAbsent(IEnvironment.Keys.LAUNCHTARGET.get(), f -> this.optionSet.valueOf(launchTarget));
         env.computePropertyIfAbsent(IEnvironment.Keys.UUID.get(), f -> this.optionSet.valueOf(uuidOption));
-        resultConsumer.accept(this.optionSet, this::optionResults);
+        resultConsumer.accept(this.optionSet, ArgumentHandler::optionResults);
     }
 
     Path[] getSpecialJars() {
@@ -66,7 +66,7 @@ public class ArgumentHandler {
         return this.optionSet.valueOf(launchTarget);
     }
 
-    private ITransformationService.OptionResult optionResults(String serviceName, OptionSet set) {
+    private static ITransformationService.OptionResult optionResults(String serviceName, OptionSet set) {
         return new ITransformationService.OptionResult() {
             @Override
             public <V> V value(OptionSpec<V> option) {

--- a/src/main/java/cpw/mods/modlauncher/ClassTransformer.java
+++ b/src/main/java/cpw/mods/modlauncher/ClassTransformer.java
@@ -27,7 +27,7 @@ import static cpw.mods.modlauncher.LogMarkers.MODLAUNCHER;
 public class ClassTransformer {
     private static final byte[] EMPTY = new byte[0];
     private static final Logger LOGGER = LogManager.getLogger();
-    private final Marker CLASSDUMP = MarkerManager.getMarker("CLASSDUMP");
+    private static final Marker CLASSDUMP = MarkerManager.getMarker("CLASSDUMP");
     private final TransformStore transformers;
     private final LaunchPluginHandler pluginHandler;
     private final TransformingClassLoader transformingClassLoader;
@@ -170,7 +170,7 @@ public class ClassTransformer {
                 transformers.remove(transformer);
                 continue;
             }
-            
+
             // If we get here and find a DEFER, it means everyone just voted to DEFER. That's an untenable state and we cannot proceed.
             if (results.containsKey(TransformerVoteResult.DEFER)) {
                 throw new VoteDeadlockException(results.get(TransformerVoteResult.DEFER), node.getClass());

--- a/src/main/java/cpw/mods/modlauncher/ClassTransformer.java
+++ b/src/main/java/cpw/mods/modlauncher/ClassTransformer.java
@@ -151,18 +151,18 @@ public class ClassTransformer {
         context.setNode(node);
         do {
             final Stream<TransformerVote<T>> voteResultStream = transformers.stream().map(t -> gatherVote(t, context));
-            final Map<TransformerVoteResult, List<TransformerVote<T>>> results = voteResultStream.collect(Collectors.groupingBy(TransformerVote::getResult));
+            final Map<TransformerVoteResult, List<TransformerVote<T>>> results = voteResultStream.collect(Collectors.groupingBy(TransformerVote::result));
             // Someone rejected the current state. We're done here, and cannot proceed.
             if (results.containsKey(TransformerVoteResult.REJECT)) {
                 throw new VoteRejectedException(results.get(TransformerVoteResult.REJECT), node.getClass());
             }
             // Remove all the "NO" voters - they don't wish to participate in further voting rounds
             if (results.containsKey(TransformerVoteResult.NO)) {
-                transformers.removeAll(results.get(TransformerVoteResult.NO).stream().map(TransformerVote::getTransformer).collect(Collectors.toList()));
+                transformers.removeAll(results.get(TransformerVoteResult.NO).stream().map(TransformerVote::transformer).toList());
             }
             // If there's at least one YES voter, let's apply the first one we find, remove them, and continue.
             if (results.containsKey(TransformerVoteResult.YES)) {
-                final ITransformer<T> transformer = results.get(TransformerVoteResult.YES).get(0).getTransformer();
+                final ITransformer<T> transformer = results.get(TransformerVoteResult.YES).get(0).transformer();
                 node = transformer.transform(node, context);
                 auditTrail.addTransformerAuditTrail(context.getClassName(), ((TransformerHolder<?>)transformer).owner(), transformer);
                 transformers.remove(transformer);

--- a/src/main/java/cpw/mods/modlauncher/ClassTransformer.java
+++ b/src/main/java/cpw/mods/modlauncher/ClassTransformer.java
@@ -125,7 +125,7 @@ public class ClassTransformer {
     }
 
     private static Path tempDir;
-    private void dumpClass(final byte[] clazz, String className) {
+    private static void dumpClass(final byte[] clazz, String className) {
         if (tempDir == null) {
             synchronized (ClassTransformer.class) {
                 if (tempDir == null) {
@@ -177,12 +177,12 @@ public class ClassTransformer {
         return node;
     }
 
-    private <T> TransformerVote<T> gatherVote(ITransformer<T> transformer, VotingContext context) {
+    private static <T> TransformerVote<T> gatherVote(ITransformer<T> transformer, VotingContext context) {
         TransformerVoteResult vr = transformer.castVote(context);
         return new TransformerVote<>(vr, transformer);
     }
 
-    private MessageDigest getSha256() {
+    private static MessageDigest getSha256() {
         try {
             return MessageDigest.getInstance("SHA-256");
         } catch (NoSuchAlgorithmException e) {

--- a/src/main/java/cpw/mods/modlauncher/EnumerationHelper.java
+++ b/src/main/java/cpw/mods/modlauncher/EnumerationHelper.java
@@ -36,6 +36,6 @@ public class EnumerationHelper {
     }
 
     public static <T> Function<String, Enumeration<T>> fromOptional(final Function<String, Optional<T>> additionalClassBytesLocator) {
-        return input -> Collections.enumeration(additionalClassBytesLocator.apply(input).map(Stream::of).orElseGet(Stream::empty).collect(Collectors.toList()));
+        return input -> Collections.enumeration(additionalClassBytesLocator.apply(input).stream().collect(Collectors.toList()));
     }
 }

--- a/src/main/java/cpw/mods/modlauncher/EnumerationHelper.java
+++ b/src/main/java/cpw/mods/modlauncher/EnumerationHelper.java
@@ -36,6 +36,6 @@ public class EnumerationHelper {
     }
 
     public static <T> Function<String, Enumeration<T>> fromOptional(final Function<String, Optional<T>> additionalClassBytesLocator) {
-        return input -> Collections.enumeration(additionalClassBytesLocator.apply(input).stream().collect(Collectors.toList()));
+        return input -> Collections.enumeration(additionalClassBytesLocator.apply(input).stream().toList());
     }
 }

--- a/src/main/java/cpw/mods/modlauncher/Environment.java
+++ b/src/main/java/cpw/mods/modlauncher/Environment.java
@@ -53,4 +53,8 @@ public final class Environment implements IEnvironment {
     public <T> T computePropertyIfAbsent(final TypesafeMap.Key<T> key, final Function<? super TypesafeMap.Key<T>, ? extends T> valueFunction) {
         return environment.computeIfAbsent(key, valueFunction);
     }
+
+    public <T> T putPropertyIfAbsent(final TypesafeMap.Key<T> key, final T value) {
+        return environment.putIfAbsent(key, value);
+    }
 }

--- a/src/main/java/cpw/mods/modlauncher/Environment.java
+++ b/src/main/java/cpw/mods/modlauncher/Environment.java
@@ -11,6 +11,7 @@ import cpw.mods.modlauncher.serviceapi.ILaunchPluginService;
 import java.util.*;
 import java.util.function.BiFunction;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 /**
  * Environment implementation class
@@ -54,6 +55,7 @@ public final class Environment implements IEnvironment {
         return environment.computeIfAbsent(key, valueFunction);
     }
 
+    @Override
     public <T> T putPropertyIfAbsent(final TypesafeMap.Key<T> key, final T value) {
         return environment.putIfAbsent(key, value);
     }

--- a/src/main/java/cpw/mods/modlauncher/LaunchPluginHandler.java
+++ b/src/main/java/cpw/mods/modlauncher/LaunchPluginHandler.java
@@ -81,7 +81,9 @@ public class LaunchPluginHandler {
     }
 
     void offerScanResultsToPlugins(List<SecureJar> scanResults) {
-        plugins.values().forEach(p -> p.addResources(scanResults));
+        for (ILaunchPluginService p : plugins.values()) {
+            p.addResources(scanResults);
+        }
     }
 
     int offerClassNodeToPlugins(Phase phase, List<ILaunchPluginService> plugins, @Nullable ClassNode node, Type className, TransformerAuditTrail auditTrail, String reason) {

--- a/src/main/java/cpw/mods/modlauncher/LaunchServiceHandler.java
+++ b/src/main/java/cpw/mods/modlauncher/LaunchServiceHandler.java
@@ -66,7 +66,7 @@ class LaunchServiceHandler {
             try {
                 var virtual = lookup.findVirtual(service.getClass(), "launchService", type);
                 Callable<Void> callable = (Callable<Void>)virtual.invokeExact(arguments, gameLayer);
-                runner = () -> callable.call();
+                runner = callable::call;
             } catch (Throwable t) {
                 sneak(t);
             }
@@ -83,7 +83,7 @@ class LaunchServiceHandler {
     static List<String> hideAccessToken(String[] arguments) {
         var output = new ArrayList<String>();
         for (int i = 0; i < arguments.length; i++) {
-            if (i > 0 && Objects.equals(arguments[i-1], "--accessToken"))
+            if (i > 0 && "--accessToken".equals(arguments[i - 1]))
                 output.add("**********");
             else
                 output.add(arguments[i]);

--- a/src/main/java/cpw/mods/modlauncher/LaunchServiceHandler.java
+++ b/src/main/java/cpw/mods/modlauncher/LaunchServiceHandler.java
@@ -29,7 +29,7 @@ import java.util.concurrent.Callable;
 /**
  * Identifies the launch target and dispatches to it
  */
-class LaunchServiceHandler {
+final class LaunchServiceHandler {
     private static final Logger LOGGER = LogManager.getLogger();
     private final Map<String, ILaunchHandlerService> handlers = new HashMap<>();
 

--- a/src/main/java/cpw/mods/modlauncher/Launcher.java
+++ b/src/main/java/cpw/mods/modlauncher/Launcher.java
@@ -70,7 +70,7 @@ public class Launcher {
             JVM information: %s %s %s
             """, props.getProperty("java.vm.vendor"), props.getProperty("java.vm.name"), props.getProperty("java.vm.version"));
         }
-        LOGGER.info(MODLAUNCHER,"ModLauncher running: args {}", () -> LaunchServiceHandler.hideAccessToken(args));
+        LOGGER.info(MODLAUNCHER,"ModLauncher running: args {}", LaunchServiceHandler.hideAccessToken(args));
         LOGGER.info(MODLAUNCHER, "JVM identified as {} {} {}", props.getProperty("java.vm.vendor"), props.getProperty("java.vm.name"), props.getProperty("java.vm.version"));
         new Launcher().run(args);
     }

--- a/src/main/java/cpw/mods/modlauncher/Launcher.java
+++ b/src/main/java/cpw/mods/modlauncher/Launcher.java
@@ -45,13 +45,13 @@ public class Launcher {
 
     private Launcher() {
         INSTANCE = this;
-        LOGGER.info(MODLAUNCHER,"ModLauncher {} starting: java version {} by {}; OS {} arch {} version {}", ()->IEnvironment.class.getPackage().getImplementationVersion(),  () -> System.getProperty("java.version"), ()->System.getProperty("java.vendor"), ()->System.getProperty("os.name"), ()->System.getProperty("os.arch"), ()->System.getProperty("os.version"));
+        LOGGER.info(MODLAUNCHER,"ModLauncher {} starting: java version {} by {}; OS {} arch {} version {}", IEnvironment.class.getPackage().getImplementationVersion(),  System.getProperty("java.version"), System.getProperty("java.vendor"), System.getProperty("os.name"), System.getProperty("os.arch"), System.getProperty("os.version"));
         this.moduleLayerHandler = new ModuleLayerHandler();
         this.launchService = new LaunchServiceHandler(this.moduleLayerHandler);
         this.blackboard = new TypesafeMap();
         this.environment = new Environment(this);
-        environment.computePropertyIfAbsent(IEnvironment.Keys.MLSPEC_VERSION.get(), s->IEnvironment.class.getPackage().getSpecificationVersion());
-        environment.computePropertyIfAbsent(IEnvironment.Keys.MLIMPL_VERSION.get(), s->IEnvironment.class.getPackage().getImplementationVersion());
+        environment.putPropertyIfAbsent(IEnvironment.Keys.MLSPEC_VERSION.get(), IEnvironment.class.getPackage().getSpecificationVersion());
+        environment.putPropertyIfAbsent(IEnvironment.Keys.MLIMPL_VERSION.get(), IEnvironment.class.getPackage().getImplementationVersion());
         environment.computePropertyIfAbsent(IEnvironment.Keys.MODLIST.get(), s->new ArrayList<>());
         environment.putPropertyIfAbsent(IEnvironment.Keys.SECURED_JARS_ENABLED.get(), ProtectionDomainHelper.canHandleSecuredJars());
         this.transformStore = new TransformStore();

--- a/src/main/java/cpw/mods/modlauncher/Launcher.java
+++ b/src/main/java/cpw/mods/modlauncher/Launcher.java
@@ -53,7 +53,7 @@ public class Launcher {
         environment.computePropertyIfAbsent(IEnvironment.Keys.MLSPEC_VERSION.get(), s->IEnvironment.class.getPackage().getSpecificationVersion());
         environment.computePropertyIfAbsent(IEnvironment.Keys.MLIMPL_VERSION.get(), s->IEnvironment.class.getPackage().getImplementationVersion());
         environment.computePropertyIfAbsent(IEnvironment.Keys.MODLIST.get(), s->new ArrayList<>());
-        environment.computePropertyIfAbsent(IEnvironment.Keys.SECURED_JARS_ENABLED.get(), k-> ProtectionDomainHelper.canHandleSecuredJars());
+        environment.putPropertyIfAbsent(IEnvironment.Keys.SECURED_JARS_ENABLED.get(), ProtectionDomainHelper.canHandleSecuredJars());
         this.transformStore = new TransformStore();
         this.transformationServicesHandler = new TransformationServicesHandler(this.transformStore, this.moduleLayerHandler);
         this.argumentHandler = new ArgumentHandler();

--- a/src/main/java/cpw/mods/modlauncher/Launcher.java
+++ b/src/main/java/cpw/mods/modlauncher/Launcher.java
@@ -52,7 +52,7 @@ public class Launcher {
         this.environment = new Environment(this);
         environment.putPropertyIfAbsent(IEnvironment.Keys.MLSPEC_VERSION.get(), IEnvironment.class.getPackage().getSpecificationVersion());
         environment.putPropertyIfAbsent(IEnvironment.Keys.MLIMPL_VERSION.get(), IEnvironment.class.getPackage().getImplementationVersion());
-        environment.computePropertyIfAbsent(IEnvironment.Keys.MODLIST.get(), s->new ArrayList<>());
+        environment.computePropertyIfAbsent(IEnvironment.Keys.MODLIST.get(), k -> new ArrayList<>());
         environment.putPropertyIfAbsent(IEnvironment.Keys.SECURED_JARS_ENABLED.get(), ProtectionDomainHelper.canHandleSecuredJars());
         this.transformStore = new TransformStore();
         this.transformationServicesHandler = new TransformationServicesHandler(this.transformStore, this.moduleLayerHandler);

--- a/src/main/java/cpw/mods/modlauncher/LogMarkers.java
+++ b/src/main/java/cpw/mods/modlauncher/LogMarkers.java
@@ -7,8 +7,10 @@ package cpw.mods.modlauncher;
 
 import org.apache.logging.log4j.*;
 
-class LogMarkers {
+final class LogMarkers {
     static final Marker MODLAUNCHER = MarkerManager.getMarker("MODLAUNCHER");
-    static final Marker CLASSLOADING = MarkerManager.getMarker("CLASSLOADING").addParents(MODLAUNCHER);
+//    static final Marker CLASSLOADING = MarkerManager.getMarker("CLASSLOADING").addParents(MODLAUNCHER);
     static final Marker LAUNCHPLUGIN = MarkerManager.getMarker("LAUNCHPLUGIN").addParents(MODLAUNCHER);
+
+    private LogMarkers() {}
 }

--- a/src/main/java/cpw/mods/modlauncher/ModuleLayerHandler.java
+++ b/src/main/java/cpw/mods/modlauncher/ModuleLayerHandler.java
@@ -58,7 +58,7 @@ public final class ModuleLayerHandler implements IModuleLayerManager {
     }
 
     LayerInfo build(Layer layer, ClassLoaderFactory classLoaderSupplier) {
-        var jars = layers.getOrDefault(layer, List.of()).stream().toArray(SecureJar[]::new);
+        var jars = layers.getOrDefault(layer, List.of()).toArray(SecureJar[]::new);
         var targets = Arrays.stream(jars).map(SecureJar::name).toList();
         var parentLayers = new ArrayList<ModuleLayer>();
         var parentConfigs = new ArrayList<Configuration>();

--- a/src/main/java/cpw/mods/modlauncher/NameMappingServiceHandler.java
+++ b/src/main/java/cpw/mods/modlauncher/NameMappingServiceHandler.java
@@ -21,7 +21,7 @@ import java.util.function.BiFunction;
 /**
  * Allow names to be transformed between naming domains.
  */
-class NameMappingServiceHandler {
+final class NameMappingServiceHandler {
     private static final Logger LOGGER = LogManager.getLogger();
     private final Map<String, INameMappingService> allKnown = new HashMap<>();
     private final Map<String, INameMappingService> active = new HashMap<>();

--- a/src/main/java/cpw/mods/modlauncher/PredicateVisitor.java
+++ b/src/main/java/cpw/mods/modlauncher/PredicateVisitor.java
@@ -14,23 +14,29 @@ import org.objectweb.asm.Opcodes;
 public class PredicateVisitor extends ClassVisitor {
     private static final int ASM_API = Opcodes.ASM9;
     
-    private ITransformerVotingContext.MethodPredicate methodPredicate;
-    private ITransformerVotingContext.FieldPredicate fieldPredicate;
-    private ITransformerVotingContext.ClassPredicate classPredicate;
+    private final ITransformerVotingContext.MethodPredicate methodPredicate;
+    private final ITransformerVotingContext.FieldPredicate fieldPredicate;
+    private final ITransformerVotingContext.ClassPredicate classPredicate;
     private boolean result;
 
     PredicateVisitor(final ITransformerVotingContext.FieldPredicate fieldPredicate) {
         super(ASM_API);
+        this.methodPredicate = null;
         this.fieldPredicate = fieldPredicate;
+        this.classPredicate = null;
     }
 
     PredicateVisitor(final ITransformerVotingContext.MethodPredicate methodPredicate) {
         super(ASM_API);
         this.methodPredicate = methodPredicate;
+        this.fieldPredicate = null;
+        this.classPredicate = null;
     }
 
     PredicateVisitor(final ITransformerVotingContext.ClassPredicate classPredicate) {
         super(ASM_API);
+        this.methodPredicate = null;
+        this.fieldPredicate = null;
         this.classPredicate = classPredicate;
     }
 

--- a/src/main/java/cpw/mods/modlauncher/TransformTargetLabel.java
+++ b/src/main/java/cpw/mods/modlauncher/TransformTargetLabel.java
@@ -26,7 +26,7 @@ import static cpw.mods.modlauncher.TransformTargetLabel.LabelType.*;
 public record TransformTargetLabel(Type className, String elementName, Type elementDescriptor, LabelType labelType) {
 
     TransformTargetLabel(ITransformer.Target target) {
-        this(target.getClassName(), target.getElementName(), target.getElementDescriptor(), LabelType.valueOf(target.getTargetType().name()));
+        this(target.className(), target.elementName(), target.elementDescriptor(), LabelType.valueOf(target.targetType().name()));
     }
 
     private TransformTargetLabel(String className, String elementName, String elementDescriptor, LabelType labelType) {

--- a/src/main/java/cpw/mods/modlauncher/TransformTargetLabel.java
+++ b/src/main/java/cpw/mods/modlauncher/TransformTargetLabel.java
@@ -5,7 +5,6 @@
 
 package cpw.mods.modlauncher;
 
-
 import org.objectweb.asm.Type;
 import org.objectweb.asm.tree.ClassNode;
 import org.objectweb.asm.tree.FieldNode;
@@ -24,21 +23,21 @@ import static cpw.mods.modlauncher.TransformTargetLabel.LabelType.*;
 /**
  * Detailed targetting information
  */
-public final class TransformTargetLabel {
+public record TransformTargetLabel(Type className, String elementName, Type elementDescriptor, LabelType labelType) {
 
-    private final Type className;
-    private final String elementName;
-    private final Type elementDescriptor;
-    private final LabelType labelType;
     TransformTargetLabel(ITransformer.Target target) {
         this(target.getClassName(), target.getElementName(), target.getElementDescriptor(), LabelType.valueOf(target.getTargetType().name()));
     }
+
     private TransformTargetLabel(String className, String elementName, String elementDescriptor, LabelType labelType) {
-        this.className = Type.getObjectType(className.replace('.', '/'));
-        this.elementName = elementName;
-        this.elementDescriptor = !elementDescriptor.isEmpty() ? Type.getMethodType(elementDescriptor) : Type.VOID_TYPE;
-        this.labelType = labelType;
+        this(
+            Type.getObjectType(className.replace('.', '/')),
+            elementName,
+            !elementDescriptor.isEmpty() ? Type.getMethodType(elementDescriptor) : Type.VOID_TYPE,
+            labelType
+        );
     }
+
     public TransformTargetLabel(String className, String fieldName) {
         this(className, fieldName, "", FIELD);
     }
@@ -58,19 +57,19 @@ public final class TransformTargetLabel {
             throw new IllegalArgumentException("Invalid type " + type + ", must be for class!");
     }
 
-    final Type getClassName() {
+    Type getClassName() {
         return this.className;
     }
 
-    public final String getElementName() {
+    public String getElementName() {
         return this.elementName;
     }
 
-    public final Type getElementDescriptor() {
+    public Type getElementDescriptor() {
         return this.elementDescriptor;
     }
 
-    final LabelType getLabelType() {
+    LabelType getLabelType() {
         return this.labelType;
     }
 
@@ -80,14 +79,11 @@ public final class TransformTargetLabel {
 
     @Override
     public boolean equals(Object obj) {
-        try {
-            TransformTargetLabel tl = (TransformTargetLabel) obj;
-            return Objects.equals(this.className, tl.className)
-                    && Objects.equals(this.elementName, tl.elementName)
-                    && Objects.equals(this.elementDescriptor, tl.elementDescriptor);
-        } catch (ClassCastException cce) {
-            return false;
-        }
+        if (obj == this) return true;
+        return obj instanceof TransformTargetLabel tl
+                && Objects.equals(this.className, tl.className)
+                && Objects.equals(this.elementName, tl.elementName)
+                && Objects.equals(this.elementDescriptor, tl.elementDescriptor);
     }
 
     @Override

--- a/src/main/java/cpw/mods/modlauncher/TransformTargetLabel.java
+++ b/src/main/java/cpw/mods/modlauncher/TransformTargetLabel.java
@@ -23,19 +23,21 @@ import static cpw.mods.modlauncher.TransformTargetLabel.LabelType.*;
 /**
  * Detailed targetting information
  */
-public record TransformTargetLabel(Type className, String elementName, Type elementDescriptor, LabelType labelType) {
+public final class TransformTargetLabel {
+    private final Type className;
+    private final String elementName;
+    private final Type elementDescriptor;
+    private final LabelType labelType;
 
     TransformTargetLabel(ITransformer.Target target) {
         this(target.className(), target.elementName(), target.elementDescriptor(), LabelType.valueOf(target.targetType().name()));
     }
 
     private TransformTargetLabel(String className, String elementName, String elementDescriptor, LabelType labelType) {
-        this(
-            Type.getObjectType(className.replace('.', '/')),
-            elementName,
-            !elementDescriptor.isEmpty() ? Type.getMethodType(elementDescriptor) : Type.VOID_TYPE,
-            labelType
-        );
+        this.className = Type.getObjectType(className.replace('.', '/'));
+        this.elementName = elementName;
+        this.elementDescriptor = !elementDescriptor.isEmpty() ? Type.getMethodType(elementDescriptor) : Type.VOID_TYPE;
+        this.labelType = labelType;
     }
 
     public TransformTargetLabel(String className, String fieldName) {

--- a/src/main/java/cpw/mods/modlauncher/TransformTargetLabel.java
+++ b/src/main/java/cpw/mods/modlauncher/TransformTargetLabel.java
@@ -36,7 +36,7 @@ public final class TransformTargetLabel {
     private TransformTargetLabel(String className, String elementName, String elementDescriptor, LabelType labelType) {
         this.className = Type.getObjectType(className.replace('.', '/'));
         this.elementName = elementName;
-        this.elementDescriptor = elementDescriptor.length() > 0 ? Type.getMethodType(elementDescriptor) : Type.VOID_TYPE;
+        this.elementDescriptor = !elementDescriptor.isEmpty() ? Type.getMethodType(elementDescriptor) : Type.VOID_TYPE;
         this.labelType = labelType;
     }
     public TransformTargetLabel(String className, String fieldName) {

--- a/src/main/java/cpw/mods/modlauncher/TransformationServicesHandler.java
+++ b/src/main/java/cpw/mods/modlauncher/TransformationServicesHandler.java
@@ -85,7 +85,9 @@ class TransformationServicesHandler {
     private void initialiseTransformationServices(Environment environment) {
         LOGGER.debug(MODLAUNCHER,"Transformation services initializing");
 
-        serviceLookup.values().forEach(s -> s.onInitialize(environment));
+        for (TransformationServiceDecorator s : serviceLookup.values()) {
+            s.onInitialize(environment);
+        }
     }
 
     private List<ITransformationService.Resource> runScanningTransformationServices(Environment environment) {
@@ -113,7 +115,9 @@ class TransformationServicesHandler {
 
     private void loadTransformationServices(Environment environment) {
         LOGGER.debug(MODLAUNCHER,"Transformation services loading");
-        serviceLookup.values().forEach(s -> s.onLoad(environment, serviceLookup.keySet()));
+        for (TransformationServiceDecorator s : serviceLookup.values()) {
+            s.onLoad(environment, serviceLookup.keySet());
+        }
     }
 
     void discoverServices(final ArgumentHandler.DiscoveryData discoveryData) {

--- a/src/main/java/cpw/mods/modlauncher/TransformationServicesHandler.java
+++ b/src/main/java/cpw/mods/modlauncher/TransformationServicesHandler.java
@@ -44,7 +44,7 @@ class TransformationServicesHandler {
         processArguments(argumentHandler, environment);
         initialiseTransformationServices(environment);
         // force the naming to "mojang" if nothing has been populated during transformer setup
-        environment.computePropertyIfAbsent(IEnvironment.Keys.NAMING.get(), a-> "mojang");
+        environment.putPropertyIfAbsent(IEnvironment.Keys.NAMING.get(), "mojang");
         nameMappingServiceHandler.bindNamingServices(environment.getProperty(Environment.Keys.NAMING.get()).orElse("mojang"));
         return runScanningTransformationServices(environment);
     }

--- a/src/main/java/cpw/mods/modlauncher/TransformationServicesHandler.java
+++ b/src/main/java/cpw/mods/modlauncher/TransformationServicesHandler.java
@@ -79,7 +79,9 @@ class TransformationServicesHandler {
     void initialiseServiceTransformers() {
         LOGGER.debug(MODLAUNCHER,"Transformation services loading transformers");
 
-        serviceLookup.values().forEach(s -> s.gatherTransformers(transformStore));
+        for (TransformationServiceDecorator s : serviceLookup.values()) {
+            s.gatherTransformers(transformStore);
+        }
     }
 
     private void initialiseTransformationServices(Environment environment) {

--- a/src/main/java/cpw/mods/modlauncher/TransformationServicesHandler.java
+++ b/src/main/java/cpw/mods/modlauncher/TransformationServicesHandler.java
@@ -94,7 +94,7 @@ class TransformationServicesHandler {
         return serviceLookup.values()
                 .stream()
                 .map(s -> s.runScan(environment))
-                .<ITransformationService.Resource>mapMulti(Iterable::forEach)
+                .flatMap(List::stream)
                 .toList();
     }
 
@@ -168,8 +168,8 @@ class TransformationServicesHandler {
 
     public List<ITransformationService.Resource> triggerScanCompletion(IModuleLayerManager moduleLayerManager) {
         return serviceLookup.values().stream()
-                .map(tsd->tsd.onCompleteScan(moduleLayerManager))
-                .<ITransformationService.Resource>mapMulti(Iterable::forEach)
+                .map(tsd -> tsd.onCompleteScan(moduleLayerManager))
+                .flatMap(List::stream)
                 .toList();
 
     }

--- a/src/main/java/cpw/mods/modlauncher/TransformationServicesHandler.java
+++ b/src/main/java/cpw/mods/modlauncher/TransformationServicesHandler.java
@@ -27,7 +27,7 @@ import java.util.function.BiFunction;
 
 import static cpw.mods.modlauncher.LogMarkers.*;
 
-class TransformationServicesHandler {
+final class TransformationServicesHandler {
     private static final Logger LOGGER = LogManager.getLogger();
     private Map<String, TransformationServiceDecorator> serviceLookup;
     private final TransformStore transformStore;

--- a/src/main/java/cpw/mods/modlauncher/TransformerAuditTrail.java
+++ b/src/main/java/cpw/mods/modlauncher/TransformerAuditTrail.java
@@ -16,7 +16,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 public class TransformerAuditTrail implements ITransformerAuditTrail {
-    private Map<String, List<ITransformerActivity>> audit = new ConcurrentHashMap<>();
+    private final Map<String, List<ITransformerActivity>> audit = new ConcurrentHashMap<>();
 
     @Override
     public List<ITransformerActivity> getActivityFor(final String className) {
@@ -43,7 +43,7 @@ public class TransformerAuditTrail implements ITransformerAuditTrail {
         }
 
         public String getActivityString() {
-            return this.type.getLabel() + ":"+ String.join(":",this.context);
+            return this.type.getLabel() + ":" + String.join(":", this.context);
         }
     }
 
@@ -63,12 +63,13 @@ public class TransformerAuditTrail implements ITransformerAuditTrail {
         getTransformerActivities(clazz).add(new TransformerActivity(ITransformerActivity.Type.TRANSFORMER, concat(transformService.name(), transformer.labels())));
     }
 
-    private String[] concat(String first, String[] rest) {
+    private static String[] concat(String first, String[] rest) {
         final String[] res = new String[rest.length + 1];
         res[0] = first;
         System.arraycopy(rest, 0, res, 1, rest.length);
         return res;
     }
+
     private List<ITransformerActivity> getTransformerActivities(final String clazz) {
         return audit.computeIfAbsent(clazz, k->new ArrayList<>());
     }

--- a/src/main/java/cpw/mods/modlauncher/TransformerAuditTrail.java
+++ b/src/main/java/cpw/mods/modlauncher/TransformerAuditTrail.java
@@ -23,13 +23,9 @@ public class TransformerAuditTrail implements ITransformerAuditTrail {
         return Collections.unmodifiableList(getTransformerActivities(className));
     }
 
-    private static class TransformerActivity implements ITransformerActivity {
-        private final Type type;
-        private final String[] context;
-
-        private TransformerActivity(Type type, String... context) {
-            this.type = type;
-            this.context = context;
+    private record TransformerActivity(String[] context, Type type) implements ITransformerActivity {
+        public TransformerActivity(Type type, String... context) {
+            this(context, type);
         }
 
         @Override

--- a/src/main/java/cpw/mods/modlauncher/TransformerClassWriter.java
+++ b/src/main/java/cpw/mods/modlauncher/TransformerClassWriter.java
@@ -71,7 +71,7 @@ class TransformerClassWriter extends ClassWriter {
         return CLASS_HIERARCHIES.get(typeName);
     }
 
-    private boolean isIntf(final String typeName) {
+    private static boolean isIntf(final String typeName) {
         //We don't need computeHierarchy as it has been called already from a different method every time this method is called
         return IS_INTERFACE.get(typeName);
     }
@@ -104,7 +104,7 @@ class TransformerClassWriter extends ClassWriter {
      * Computes the hierarchy for a specific class using the already loaded class object
      * Must be kept in sync with the file counterpart {@link SuperCollectingVisitor#visit(int, int, String, String, String, String[])}
      */
-    private void computeHierarchyFromClass(final String name, final Class<?> clazz) {
+    private static void computeHierarchyFromClass(final String name, final Class<?> clazz) {
         Class<?> superClass = clazz.getSuperclass();
         Set<String> hierarchies = new HashSet<>();
         if (superClass != null) {

--- a/src/main/java/cpw/mods/modlauncher/TransformerClassWriter.java
+++ b/src/main/java/cpw/mods/modlauncher/TransformerClassWriter.java
@@ -18,7 +18,7 @@ import org.objectweb.asm.tree.ClassNode;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
-class TransformerClassWriter extends ClassWriter {
+final class TransformerClassWriter extends ClassWriter {
     private static final Logger LOGGER = LogManager.getLogger();
     private static final Map<String, String> CLASS_PARENTS = new ConcurrentHashMap<>();
     private static final Map<String, Set<String>> CLASS_HIERARCHIES = new ConcurrentHashMap<>();
@@ -150,7 +150,7 @@ class TransformerClassWriter extends ClassWriter {
         }
     }
 
-    private class SuperCollectingVisitor extends ClassVisitor {
+    private final class SuperCollectingVisitor extends ClassVisitor {
 
         public SuperCollectingVisitor() {
             super(Opcodes.ASM9);

--- a/src/main/java/cpw/mods/modlauncher/TransformerClassWriter.java
+++ b/src/main/java/cpw/mods/modlauncher/TransformerClassWriter.java
@@ -118,13 +118,13 @@ class TransformerClassWriter extends ClassWriter {
             hierarchies.add("java/lang/Object");
         }
         IS_INTERFACE.put(name, clazz.isInterface());
-        Arrays.stream(clazz.getInterfaces()).forEach(c->{
+        for (Class<?> c : clazz.getInterfaces()) {
             String n = c.getName().replace('.', '/');
             if (!CLASS_HIERARCHIES.containsKey(n))
                 computeHierarchyFromClass(n, c);
             hierarchies.add(n);
             hierarchies.addAll(CLASS_HIERARCHIES.get(n));
-        });
+        }
         CLASS_HIERARCHIES.put(name, hierarchies); //Only put the set in the map once it is fully populated, to prevent another thread from using incomplete data
     }
 
@@ -168,11 +168,11 @@ class TransformerClassWriter extends ClassWriter {
                 hierarchies.add("java/lang/Object");
             }
             IS_INTERFACE.put(name, (access & Opcodes.ACC_INTERFACE) != 0);
-            Arrays.stream(interfaces).forEach(n->{
+            for (String n : interfaces) {
                 computeHierarchy(n);
                 hierarchies.add(n);
                 hierarchies.addAll(CLASS_HIERARCHIES.get(n));
-            });
+            }
             CLASS_HIERARCHIES.put(name, hierarchies); //Only put the set in the map once it is fully populated, to prevent another thread from using incomplete data
         }
     }

--- a/src/main/java/cpw/mods/modlauncher/TransformerVote.java
+++ b/src/main/java/cpw/mods/modlauncher/TransformerVote.java
@@ -7,20 +7,4 @@ package cpw.mods.modlauncher;
 
 import cpw.mods.modlauncher.api.*;
 
-class TransformerVote<T> {
-    private final ITransformer<T> transformer;
-    private final TransformerVoteResult result;
-
-    TransformerVote(TransformerVoteResult vr, ITransformer<T> transformer) {
-        this.transformer = transformer;
-        this.result = vr;
-    }
-
-    TransformerVoteResult getResult() {
-        return result;
-    }
-
-    ITransformer<T> getTransformer() {
-        return transformer;
-    }
-}
+record TransformerVote<T>(TransformerVoteResult result, ITransformer<T> transformer) {}

--- a/src/main/java/cpw/mods/modlauncher/TransformingClassLoader.java
+++ b/src/main/java/cpw/mods/modlauncher/TransformingClassLoader.java
@@ -39,7 +39,7 @@ public class TransformingClassLoader extends ModuleClassLoader {
             TransformStore transformStore, LaunchPluginHandler pluginHandler, Environment environment) {
         super(name, parent, config, parentLayers, parentLoaders, true);
         TransformerAuditTrail tat = new TransformerAuditTrail();
-        environment.computePropertyIfAbsent(IEnvironment.Keys.AUDITTRAIL.get(), v->tat);
+        environment.putPropertyIfAbsent(IEnvironment.Keys.AUDITTRAIL.get(), tat);
         this.classTransformer = new ClassTransformer(transformStore, pluginHandler, this, tat);
     }
 

--- a/src/main/java/cpw/mods/modlauncher/TransformingClassLoader.java
+++ b/src/main/java/cpw/mods/modlauncher/TransformingClassLoader.java
@@ -23,7 +23,11 @@ public class TransformingClassLoader extends ModuleClassLoader {
     private final ClassTransformer classTransformer;
 
     private static ModuleLayer get(ModuleLayerHandler layers, Layer layer) {
-        return layers.getLayer(layer).orElseThrow(() -> new NullPointerException("Failed to find " + layer.name() + " layer"));
+        var moduleLayer = layers.getLayer(layer).orElse(null);
+        if (moduleLayer == null)
+            throw new NullPointerException("Failed to find " + layer.name() + " layer");
+
+        return moduleLayer;
     }
 
     public TransformingClassLoader(TransformStore transformStore, LaunchPluginHandler pluginHandler, ModuleLayerHandler layers) {

--- a/src/main/java/cpw/mods/modlauncher/TransformingClassLoaderBuilder.java
+++ b/src/main/java/cpw/mods/modlauncher/TransformingClassLoaderBuilder.java
@@ -8,15 +8,13 @@ package cpw.mods.modlauncher;
 import cpw.mods.modlauncher.api.ITransformingClassLoaderBuilder;
 
 import java.net.URL;
-import java.net.URLConnection;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.function.Function;
-import java.util.jar.Manifest;
 
 import static cpw.mods.modlauncher.api.LamdbaExceptionUtils.rethrowFunction;
 
-class TransformingClassLoaderBuilder implements ITransformingClassLoaderBuilder {
+final class TransformingClassLoaderBuilder implements ITransformingClassLoaderBuilder {
     private final List<Path> transformationPaths = new ArrayList<>();
     private Function<String, Enumeration<URL>> resourcesLocator;
 

--- a/src/main/java/cpw/mods/modlauncher/VotingContext.java
+++ b/src/main/java/cpw/mods/modlauncher/VotingContext.java
@@ -14,7 +14,7 @@ import java.util.function.Supplier;
 /**
  * The internal vote context structure.
  */
-class VotingContext implements ITransformerVotingContext {
+final class VotingContext implements ITransformerVotingContext {
     private static final Object[] EMPTY = new Object[0];
     private final String className;
     private final boolean classExists;

--- a/src/main/java/cpw/mods/modlauncher/VotingContext.java
+++ b/src/main/java/cpw/mods/modlauncher/VotingContext.java
@@ -95,13 +95,11 @@ class VotingContext implements ITransformerVotingContext {
         return result;
     }
 
-    private Object[] toObjectArray(final AbstractInsnNode insnNode) {
-        if (insnNode instanceof MethodInsnNode) {
-            final MethodInsnNode methodInsnNode = (MethodInsnNode) insnNode;
+    private static Object[] toObjectArray(final AbstractInsnNode insnNode) {
+        if (insnNode instanceof MethodInsnNode methodInsnNode) {
             return new Object[] {methodInsnNode.name, methodInsnNode.desc, methodInsnNode.owner, methodInsnNode.itf};
         }
-        if (insnNode instanceof FieldInsnNode) {
-            final FieldInsnNode fieldInsnNode = (FieldInsnNode) insnNode;
+        if (insnNode instanceof FieldInsnNode fieldInsnNode) {
             return new Object[] {fieldInsnNode.name, fieldInsnNode.desc, fieldInsnNode.owner};
         }
         return EMPTY;

--- a/src/main/java/cpw/mods/modlauncher/VotingContext.java
+++ b/src/main/java/cpw/mods/modlauncher/VotingContext.java
@@ -14,31 +14,18 @@ import java.util.function.Supplier;
 /**
  * The internal vote context structure.
  */
-final class VotingContext implements ITransformerVotingContext {
+record VotingContext(
+        String getClassName,
+        boolean doesClassExist,
+        Supplier<byte[]> sha256,
+        List<ITransformerActivity> getAuditActivities,
+        String reason,
+        NodeHolder node
+) implements ITransformerVotingContext {
     private static final Object[] EMPTY = new Object[0];
-    private final String className;
-    private final boolean classExists;
-    private final Supplier<byte[]> sha256;
-    private final List<ITransformerActivity> auditActivities;
-    private final String reason;
-    private Object node;
 
-    VotingContext(String className, boolean classExists, Supplier<byte[]> sha256sum, final List<ITransformerActivity> activities, final String reason) {
-        this.className = className;
-        this.classExists = classExists;
-        this.sha256 = sha256sum;
-        this.auditActivities = activities;
-        this.reason = reason;
-    }
-
-    @Override
-    public String getClassName() {
-        return className;
-    }
-
-    @Override
-    public boolean doesClassExist() {
-        return classExists;
+    VotingContext(String className, boolean classExists, Supplier<byte[]> sha256sum, List<ITransformerActivity> activities, String reason) {
+        this(className, classExists, sha256sum, activities, reason, new NodeHolder());
     }
 
     @Override
@@ -47,22 +34,17 @@ final class VotingContext implements ITransformerVotingContext {
     }
 
     @Override
-    public List<ITransformerActivity> getAuditActivities() {
-        return auditActivities;
-    }
-
-    @Override
     public String getReason() {
         return reason;
     }
 
     <T> void setNode(final T node) {
-        this.node = node;
+        this.node.value = node;
     }
 
     @Override
     public boolean applyFieldPredicate(FieldPredicate fieldPredicate) {
-        FieldNode fn = (FieldNode) this.node;
+        FieldNode fn = (FieldNode) this.node.value;
         final PredicateVisitor predicateVisitor = new PredicateVisitor(fieldPredicate);
         fn.accept(predicateVisitor);
         return predicateVisitor.getResult();
@@ -70,7 +52,7 @@ final class VotingContext implements ITransformerVotingContext {
 
     @Override
     public boolean applyMethodPredicate(MethodPredicate methodPredicate) {
-        MethodNode mn = (MethodNode) this.node;
+        MethodNode mn = (MethodNode) this.node.value;
         final PredicateVisitor predicateVisitor = new PredicateVisitor(methodPredicate);
         mn.accept(predicateVisitor);
         return predicateVisitor.getResult();
@@ -78,7 +60,7 @@ final class VotingContext implements ITransformerVotingContext {
 
     @Override
     public boolean applyClassPredicate(ClassPredicate classPredicate) {
-        ClassNode cn = (ClassNode) this.node;
+        ClassNode cn = (ClassNode) this.node.value;
         final PredicateVisitor predicateVisitor = new PredicateVisitor(classPredicate);
         cn.accept(predicateVisitor);
         return predicateVisitor.getResult();
@@ -86,7 +68,7 @@ final class VotingContext implements ITransformerVotingContext {
 
     @Override
     public boolean applyInstructionPredicate(InsnPredicate insnPredicate) {
-        MethodNode mn = (MethodNode) this.node;
+        MethodNode mn = (MethodNode) this.node.value;
         boolean result = false;
         final AbstractInsnNode[] insnNodes = mn.instructions.toArray();
         for (int i = 0; i < insnNodes.length; i++) {
@@ -103,5 +85,9 @@ final class VotingContext implements ITransformerVotingContext {
             return new Object[] {fieldInsnNode.name, fieldInsnNode.desc, fieldInsnNode.owner};
         }
         return EMPTY;
+    }
+
+    private static final class NodeHolder {
+        private Object value;
     }
 }

--- a/src/main/java/cpw/mods/modlauncher/api/IEnvironment.java
+++ b/src/main/java/cpw/mods/modlauncher/api/IEnvironment.java
@@ -33,6 +33,16 @@ public interface IEnvironment {
      * @return The value of the key
      */
     <T> T computePropertyIfAbsent(TypesafeMap.Key<T> key, final Function<? super TypesafeMap.Key<T>, ? extends T> valueFunction);
+
+    /**
+     * Insert a value into the environment if not already present.
+     * @param key to insert
+     * @param value the value to insert
+     * @return The value of the key
+     * @param <T> Type of key
+     */
+    <T> T putPropertyIfAbsent(TypesafeMap.Key<T> key, T value);
+
     /**
      * Find the named {@link ILaunchPluginService}
      *

--- a/src/main/java/cpw/mods/modlauncher/api/IEnvironment.java
+++ b/src/main/java/cpw/mods/modlauncher/api/IEnvironment.java
@@ -28,11 +28,23 @@ public interface IEnvironment {
      * Compute a new value for insertion into the environment, if not already present.
      *
      * @param key to insert
-     * @param valueFunction the supplier of a value
+     * @param valueFunction the function to compute a value
      * @param <T> Type of key
      * @return The value of the key
      */
     <T> T computePropertyIfAbsent(TypesafeMap.Key<T> key, final Function<? super TypesafeMap.Key<T>, ? extends T> valueFunction);
+
+    /**
+     * Compute a new value for insertion into the environment, if not already present.
+     *
+     * @param key to insert
+     * @param valueSupplier the supplier of a value
+     * @param <T> Type of key
+     * @return The value of the key
+     */
+    default <T> T computePropertyIfAbsent(TypesafeMap.Key<T> key, final Supplier<? extends T> valueSupplier) {
+        return computePropertyIfAbsent(key, k -> valueSupplier.get());
+    }
 
     /**
      * Insert a value into the environment if not already present.

--- a/src/main/java/cpw/mods/modlauncher/api/IEnvironment.java
+++ b/src/main/java/cpw/mods/modlauncher/api/IEnvironment.java
@@ -41,7 +41,9 @@ public interface IEnvironment {
      * @return The value of the key
      * @param <T> Type of key
      */
-    <T> T putPropertyIfAbsent(TypesafeMap.Key<T> key, T value);
+    default <T> T putPropertyIfAbsent(TypesafeMap.Key<T> key, T value) {
+        return computePropertyIfAbsent(key, k -> value);
+    }
 
     /**
      * Find the named {@link ILaunchPluginService}

--- a/src/main/java/cpw/mods/modlauncher/api/IModuleLayerManager.java
+++ b/src/main/java/cpw/mods/modlauncher/api/IModuleLayerManager.java
@@ -19,6 +19,10 @@ public interface IModuleLayerManager {
 
         private final List<Layer> parents;
 
+        Layer(Layer parent) {
+            this.parents = List.of(parent);
+        }
+
         Layer(Layer... parent) {
             this.parents = List.of(parent);
         }

--- a/src/main/java/cpw/mods/modlauncher/api/ITransformer.java
+++ b/src/main/java/cpw/mods/modlauncher/api/ITransformer.java
@@ -58,7 +58,7 @@ public interface ITransformer<T> {
 
     /**
      * Return a set of {@link Target} identifying which elements this transformer wishes to try
-     * and apply to. The {@link Target#getTargetType()} must match the T variable for the transformer
+     * and apply to. The {@link Target#targetType()} must match the T variable for the transformer
      * as documented in {@link TargetType}, other combinations will be rejected.
      *
      * @return The set of targets this transformer wishes to apply to
@@ -98,37 +98,27 @@ public interface ITransformer<T> {
 
     /**
      * Simple data holder indicating where the {@link ITransformer} can target.
+     * @param className         The name of the class being targeted
+     * @param elementName       The name of the element being targeted. This is the field name for a field,
+     *                          the method name for a method. Empty string for other types
+     * @param elementDescriptor The method's descriptor. Empty string for other types
+     * @param targetType        The {@link TargetType} for this target - it should match the ITransformer
+     *                          type variable T
      */
     @SuppressWarnings("SameParameterValue")
-    final class Target {
-        private final String className;
-        private final String elementName;
-        private final String elementDescriptor;
-        private final TargetType targetType;
-
+    record Target(String className, String elementName, String elementDescriptor, TargetType targetType) {
         /**
          * Build a new target. Ensure that the targetType matches the T type for the ITransformer
          * supplying the target.
          * <p>
          * In an obfuscated environment, this will be the obfuscated "notch" naming, in a
          * deobfuscated environment this will be the searge naming.
-         *
-         * @param className         The name of the class being targetted
-         * @param elementName       The name of the element being targetted. This is the field name for a field,
-         *                          the method name for a method. Empty string for other types
-         * @param elementDescriptor The method's descriptor. Empty string for other types
-         * @param targetType        The {@link TargetType} for this target - it should match the ITransformer
-         *                          type variable T
          */
-        Target(String className, String elementName, String elementDescriptor, TargetType targetType) {
+        public Target {
             Objects.requireNonNull(className, "Class Name cannot be null");
             Objects.requireNonNull(elementName, "Element Name cannot be null");
             Objects.requireNonNull(elementDescriptor, "Element Descriptor cannot be null");
             Objects.requireNonNull(targetType, "Target Type cannot be null");
-            this.className = className;
-            this.elementName = elementName;
-            this.elementDescriptor = elementDescriptor;
-            this.targetType = targetType;
         }
 
         /**

--- a/src/main/java/cpw/mods/modlauncher/api/TypesafeMap.java
+++ b/src/main/java/cpw/mods/modlauncher/api/TypesafeMap.java
@@ -34,9 +34,18 @@ public final class TypesafeMap {
         return computeIfAbsent(this.map, key, valueFunction);
     }
 
+    public <V> V putIfAbsent(Key<V> key, V value) {
+        return putIfAbsent(this.map, key, value);
+    }
+
     @SuppressWarnings("unchecked")
-    private <C1, C2, V> V computeIfAbsent(ConcurrentHashMap<C1, C2> map, Key<V> key, Function<? super Key<V>, ? extends V> valueFunction) {
+    private static <C1, C2, V> V computeIfAbsent(ConcurrentHashMap<C1, C2> map, Key<V> key, Function<? super Key<V>, ? extends V> valueFunction) {
         return (V) map.computeIfAbsent((C1) key, (Function<? super C1, ? extends C2>) valueFunction);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <C1, C2, V extends C2> V putIfAbsent(ConcurrentHashMap<C1, C2> map, Key<?> key, V value) {
+        return (V) map.putIfAbsent((C1) key, value);
     }
 
     private ConcurrentHashMap<String, Key<Object>> getKeyIdentifiers() {

--- a/src/main/java/cpw/mods/modlauncher/api/TypesafeMap.java
+++ b/src/main/java/cpw/mods/modlauncher/api/TypesafeMap.java
@@ -77,16 +77,12 @@ public final class TypesafeMap {
 
         @Override
         public int hashCode() {
-            return (int) (this.uniqueId ^ (this.uniqueId >>> 32));
+            return Long.hashCode(this.uniqueId);
         }
 
         @Override
         public boolean equals(Object obj) {
-            try {
-                return this.uniqueId == ((Key) obj).uniqueId;
-            } catch (ClassCastException cc) {
-                return false;
-            }
+            return obj instanceof Key<?> key && this.uniqueId == key.uniqueId;
         }
 
         @Override

--- a/src/main/java/cpw/mods/modlauncher/log/TransformingThrowablePatternConverter.java
+++ b/src/main/java/cpw/mods/modlauncher/log/TransformingThrowablePatternConverter.java
@@ -85,7 +85,6 @@ public class TransformingThrowablePatternConverter extends ThrowablePatternConve
             for (var line : audit.get(cls))
                 line(buf, "    ", line);
         }
-        System.currentTimeMillis();
     }
 
     private void line(StringBuilder sb, String... parts) {

--- a/src/main/java/cpw/mods/modlauncher/util/ServiceLoaderUtils.java
+++ b/src/main/java/cpw/mods/modlauncher/util/ServiceLoaderUtils.java
@@ -33,10 +33,10 @@ public final class ServiceLoaderUtils {
     public static String fileNameFor(Class<?> clazz) {
         var module = clazz.getModule();
         var ref = module.getLayer().configuration().findModule(module.getName());
-        if (!ref.isPresent())
+        if (ref.isEmpty())
             return "MISSING FILE";
         var location = ref.get().reference().location();
-        if (!location.isPresent())
+        if (location.isEmpty())
             return "MISSING FILE";
 
         var path = Path.of(location.get());


### PR DESCRIPTION
This PR does a big general cleanup to ModLauncher... at least what is doable without intentional breaking changes.

New features:
- Environment#putPropertyIfAbsent

Cleanup:
- Stream#mapMulti -> Stream#flatMap
- More records
- Less allocating lambdas and streams
- More static methods and finals
- More pattern matching instanceof

Open questions:
- Can LaunchServiceHandler.identifyTransformationTargets() be removed?
- Should LamdbaExceptionUtils be deprecated and bounce to a new class that's spelt correctly?