### PR TITLE
Downgrade jopt-simple from 6.0-alpha-3 to 5.0.4

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -6,7 +6,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'org.gradle.toolchains.foojay-resolver-convention' version '0.8.0'
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '0.9.0'
 }
 
 dependencyResolutionManagement {
@@ -27,7 +27,7 @@ dependencyResolutionManagement {
             library('nulls', 'org.jetbrains:annotations:24.1.0')
             library('unsafe', 'net.minecraftforge:unsafe:0.9.2')
             library('securemodules', 'net.minecraftforge:securemodules:2.2.14')
-            library('jopt-simple', 'net.sf.jopt-simple:jopt-simple:6.0-alpha-3')
+            library('jopt-simple', 'net.sf.jopt-simple:jopt-simple:5.0.4')
             library('bootstrap-api', 'net.minecraftforge:bootstrap-api:2.0.0')
 
             version('log4j', '2.22.1')


### PR DESCRIPTION
Fixes transitive version mismatches in Forge